### PR TITLE
Potential fix for code scanning alert no. 309: Implicit narrowing conversion in compound assignment

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Stories/StoryCaptionView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Stories/StoryCaptionView.java
@@ -329,7 +329,7 @@ public class StoryCaptionView extends NestedScrollView {
             if (overScrollY > 0) {
                 if (delta < 0) {
                     overScrollY = 0;
-                    consumed[1] += dy + delta;
+                    consumed[1] += (int)(dy + delta);
                 } else {
                     overScrollY = delta;
                     consumed[1] += dy;


### PR DESCRIPTION
Potential fix for [https://github.com/FlutterGenerator/Telegram/security/code-scanning/309](https://github.com/FlutterGenerator/Telegram/security/code-scanning/309)

To fix the problem, we should make the narrowing conversion explicit by casting the result of `dy + delta` to `int` before adding it to `consumed[1]`. This makes the truncation of the float value explicit and clear to readers and static analysis tools. The best way to do this is to wrap the sum in an explicit cast: `consumed[1] += (int)(dy + delta);`. This change should be made only on the flagged line (line 332) in the file `TMessagesProj/src/main/java/org/telegram/ui/Stories/StoryCaptionView.java`. No additional imports or method definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
