### PR TITLE
Potential fix for code scanning alert no. 324: Implicit narrowing conversion in compound assignment

### DIFF
--- a/TMessagesProj_AppStandalone/src/main/java/org/telegram/ui/SMSStatsActivity.java
+++ b/TMessagesProj_AppStandalone/src/main/java/org/telegram/ui/SMSStatsActivity.java
@@ -104,8 +104,8 @@ public class SMSStatsActivity extends GradientHeaderActivity implements Notifica
                 int w = Theme.dialogs_errorDrawable.getIntrinsicWidth();
                 int h = Theme.dialogs_errorDrawable.getIntrinsicHeight();
                 if (sz < 18) {
-                    w *= .8f;
-                    h *= .8f;
+                    w = (int)(w * 0.8f);
+                    h = (int)(h * 0.8f);
                 }
                 Theme.dialogs_errorDrawable.setBounds((int) (getIntrinsicWidth() / 2f - w / 2), (int) (getIntrinsicHeight() / 2f - h / 2), (int) (getIntrinsicWidth() / 2f + w / 2), (int) (getIntrinsicHeight() / 2f + h / 2));
                 Theme.dialogs_errorDrawable.draw(canvas);


### PR DESCRIPTION
Potential fix for [https://github.com/FlutterGenerator/Telegram/security/code-scanning/324](https://github.com/FlutterGenerator/Telegram/security/code-scanning/324)

To fix the implicit narrowing conversion, explicitly cast the result of the multiplication to `int` before assigning it back to `w` and `h`. This makes the conversion clear and intentional, improving code readability and maintainability. The change should be made in the anonymous `Drawable` class within the `error(int sz)` method, specifically on lines 107 and 108, where `w` and `h` are scaled by `0.8f`. Change `w *= .8f;` to `w = (int)(w * 0.8f);` and similarly for `h`. No additional imports or method definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
