### PR TITLE
Potential fix for code scanning alert no. 323: Implicit narrowing conversion in compound assignment

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/TopicsFragment.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/TopicsFragment.java
@@ -1059,7 +1059,7 @@ public class TopicsFragment extends BaseFragment implements NotificationCenter.N
                             k = 1f;
                         }
                         recyclerListView.setOverScrollMode(View.OVER_SCROLL_NEVER);
-                        measuredDy *= PullForegroundDrawable.startPullParallax - PullForegroundDrawable.endPullParallax * k;
+                        measuredDy = (int) (measuredDy * (PullForegroundDrawable.startPullParallax - PullForegroundDrawable.endPullParallax * k));
                         if (measuredDy > -1) {
                             measuredDy = -1;
                         }


### PR DESCRIPTION
Potential fix for [https://github.com/FlutterGenerator/Telegram/security/code-scanning/323](https://github.com/FlutterGenerator/Telegram/security/code-scanning/323)

To fix the implicit narrowing conversion, the calculation should be performed using a temporary `float` variable, and then the result should be explicitly cast to `int` before assigning it to `measuredDy`. This makes the narrowing conversion explicit and clear to readers and static analysis tools. Specifically, replace the compound assignment `measuredDy *= ...` with `measuredDy = (int)(measuredDy * ...);`. This change should be made only at the flagged line (line 1062) in `TMessagesProj/src/main/java/org/telegram/ui/TopicsFragment.java`. No new imports or method definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
