### PR TITLE
Potential fix for code scanning alert no. 72: Overly permissive regular expression range

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/LaunchActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/LaunchActivity.java
@@ -236,7 +236,7 @@ import java.util.zip.ZipInputStream;
 public class LaunchActivity extends BasePermissionsActivity implements INavigationLayout.INavigationLayoutDelegate, NotificationCenter.NotificationCenterDelegate, DialogsActivity.DialogsActivityDelegate, IPipActivity {
     public final static String EXTRA_FORCE_NOT_INTERNAL_APPS = "force_not_internal_apps";
     public final static String EXTRA_FORCE_REQUEST = "force_request";
-    public final static Pattern PREFIX_T_ME_PATTERN = Pattern.compile("^(?:http(?:s|)://|)([A-z0-9-]+?)\\.t\\.me");
+    public final static Pattern PREFIX_T_ME_PATTERN = Pattern.compile("^(?:http(?:s|)://|)([A-Za-z0-9-]+?)\\.t\\.me");
 
     public static boolean isActive;
     public static boolean isResumed;


### PR DESCRIPTION
Potential fix for [https://github.com/FlutterGenerator/Telegram/security/code-scanning/72](https://github.com/FlutterGenerator/Telegram/security/code-scanning/72)

To fix the problem, the character range in the regular expression should be changed from `[A-z0-9-]` to `[A-Za-z0-9-]`. This ensures that only uppercase and lowercase English letters, digits, and hyphens are matched, and not the unintended special characters between `Z` and `a` in the ASCII table. The change should be made only on line 239 in the file `TMessagesProj/src/main/java/org/telegram/ui/LaunchActivity.java`. No additional imports or method changes are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
