### PR TITLE
Potential fix for code scanning alert no. 322: Implicit narrowing conversion in compound assignment

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Stories/recorder/TimelineView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Stories/recorder/TimelineView.java
@@ -1971,7 +1971,7 @@ public class TimelineView extends View {
                 for (int j = 0; j < waveforms.size(); ++j) {
                     short bar = waveforms.get(j) == null || i >= waveforms.get(j).getCount() ? 0 : waveforms.get(j).getBar(i);
                     if (i < animatedLoaded.get(j) && i + 1 > animatedLoaded.get(j)) {
-                        bar *= (animatedLoaded.get(j) - i);
+                        bar = (short)(bar * (animatedLoaded.get(j) - i));
                     } else if (i > animatedLoaded.get(j)) {
                         bar = 0;
                     }


### PR DESCRIPTION
Potential fix for [https://github.com/FlutterGenerator/Telegram/security/code-scanning/322](https://github.com/FlutterGenerator/Telegram/security/code-scanning/322)

To fix the problem, we should avoid the implicit narrowing conversion in the compound assignment. The best way is to perform the multiplication in a wider type (`float`), then explicitly cast the result to `short` when assigning back to `bar`. This makes the narrowing conversion explicit and clear to readers and static analysis tools. Specifically, replace `bar *= (animatedLoaded.get(j) - i);` with `bar = (short)(bar * (animatedLoaded.get(j) - i));`. This change should be made in the method `layout` in the inner class (or method) in `TimelineView.java`, at the indicated line.

No new imports or method definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
