### PR TITLE
Potential fix for code scanning alert no. 319: Implicit narrowing conversion in compound assignment

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Stories/recorder/PaintView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Stories/recorder/PaintView.java
@@ -2947,7 +2947,7 @@ public class PaintView extends SizeNotifierFrameLayoutPhoto implements IPhotoPai
                                     final float dy = cy * scaleY - v.getHeight() / 2.0f * scaleY;
                                     final float a = (float) (v.getRotation() / 180.0f * Math.PI);
                                     stickerEntity.x += dx * Math.cos(a) - dy * Math.sin(a);
-                                    stickerEntity.y += dx * Math.sin(a) + dy * Math.cos(a);
+                                    stickerEntity.y += (float) (dx * Math.sin(a) + dy * Math.cos(a));
                                     stickerEntity.x += -size / 2.0f * scaleX;
                                     stickerEntity.y += -size / 2.0f * scaleY;
                                     stickerEntity.x /= entitiesView.getMeasuredWidth();


### PR DESCRIPTION
Potential fix for [https://github.com/FlutterGenerator/Telegram/security/code-scanning/319](https://github.com/FlutterGenerator/Telegram/security/code-scanning/319)

To fix the problem, we should make the narrowing conversion explicit by casting the right-hand side of the compound assignment to `float`. This removes the implicit cast and makes it clear that the loss of precision is intentional and acceptable for this context. Specifically, in file `TMessagesProj/src/main/java/org/telegram/ui/Stories/recorder/PaintView.java`, on line 2950, change:

```java
stickerEntity.y += dx * Math.sin(a) + dy * Math.cos(a);
```

to

```java
stickerEntity.y += (float) (dx * Math.sin(a) + dy * Math.cos(a));
```

No imports or additional definitions are required, as casting to `float` is a standard Java operation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
