### PR TITLE
Potential fix for code scanning alert no. 326: Implicit narrowing conversion in compound assignment

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Stories/recorder/PaintView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Stories/recorder/PaintView.java
@@ -2946,7 +2946,7 @@ public class PaintView extends SizeNotifierFrameLayoutPhoto implements IPhotoPai
                                     final float dx = cx * scaleX - v.getWidth() / 2.0f * scaleX;
                                     final float dy = cy * scaleY - v.getHeight() / 2.0f * scaleY;
                                     final float a = (float) (v.getRotation() / 180.0f * Math.PI);
-                                    stickerEntity.x += dx * Math.cos(a) - dy * Math.sin(a);
+                                    stickerEntity.x += (float) (dx * Math.cos(a) - dy * Math.sin(a));
                                     stickerEntity.y += (float) (dx * Math.sin(a) + dy * Math.cos(a));
                                     stickerEntity.x += -size / 2.0f * scaleX;
                                     stickerEntity.y += -size / 2.0f * scaleY;


### PR DESCRIPTION
Potential fix for [https://github.com/FlutterGenerator/Telegram/security/code-scanning/326](https://github.com/FlutterGenerator/Telegram/security/code-scanning/326)

To fix the implicit narrowing conversion, explicitly cast the result of the right-hand side expression to `float` before performing the compound assignment. This makes the conversion explicit and silences the warning, while preserving the intended functionality. Specifically, change line 2949 from:
```java
stickerEntity.x += dx * Math.cos(a) - dy * Math.sin(a);
```
to:
```java
stickerEntity.x += (float) (dx * Math.cos(a) - dy * Math.sin(a));
```
No additional imports or method definitions are required, as casting to `float` is a standard Java operation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
