### PR TITLE
Potential fix for code scanning alert no. 317: Implicit narrowing conversion in compound assignment

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Stories/recorder/PreviewView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Stories/recorder/PreviewView.java
@@ -1927,7 +1927,7 @@ public class PreviewView extends FrameLayout {
                     float scale = Math.max(100f / w, 100f / h);
                     if (scale > 1) {
                         w *= scale;
-                        h *= scale;
+                        h = Math.round(h * scale);
                     }
                     Bitmap bitmap = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888);
                     wallpaperDrawable.setBounds(0, 0, w, h);


### PR DESCRIPTION
Potential fix for [https://github.com/FlutterGenerator/Telegram/security/code-scanning/317](https://github.com/FlutterGenerator/Telegram/security/code-scanning/317)

To fix the problem, we should make the narrowing conversion explicit and, ideally, use a rounding method to avoid silent truncation. The best practice is to use `Math.round()` to convert the result of the multiplication to the nearest integer, rather than simply truncating the decimal part. This makes the conversion explicit and the intent clear, reducing the risk of subtle bugs. The change should be made only to the line `h *= scale;` in the `setupWallpaper` method, replacing it with `h = Math.round(h * scale);`. No new imports are needed, as `Math.round()` is part of `java.lang.Math`, which is always available.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
